### PR TITLE
[#15]feat: 캐러셀 컴포넌트 구현

### DIFF
--- a/src/shared/Carousel.jsx
+++ b/src/shared/Carousel.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+class Carousel extends React.Component {
+  state = {
+    startIndex: this.props.startIndex,
+    images: this.props.images,
+    carousel: null,
+    translate3d: 'translate3d(0, 0, 0)',
+    onPrev: this.onPrev.bind(this),
+    onNext: this.onNext.bind(this),
+  };
+
+  componentDidMount() {
+    this.setState((state) => {
+      return (state.carousel = document.querySelector('.carousel'));
+    });
+  }
+
+  onPrev() {
+    if (this.state.startIndex === 0) return;
+
+    this.setState((state) => {
+      return {
+        ...state,
+        startIndex: (state.startIndex -= 1),
+        translate3d: `translate3d(-${614 * state.startIndex}px, 0, 0)`,
+      };
+    });
+  }
+
+  onNext() {
+    if (this.state.startIndex === this.state.images.length - 1) return;
+
+    this.setState((state) => {
+      return {
+        ...state,
+        startIndex: (state.startIndex += 1),
+        translate3d: `translate3d(-${614 * state.startIndex}px, 0, 0)`,
+      };
+    });
+  }
+
+  render() {
+    return (
+      <>
+        <div className='carousel-wrapper'>
+          <div
+            className='carousel'
+            style={{ transform: this.state.translate3d }}>
+            {this.state.images.map((image, index) => (
+              <img key={index} src={image.src} />
+            ))}
+          </div>
+          <button className='prev' type='button' onClick={this.state.onPrev}>
+            <div className='prev-image'></div>
+          </button>
+          <button className='next' type='button' onClick={this.state.onNext}>
+            <div className='next-image'></div>
+          </button>
+        </div>
+      </>
+    );
+  }
+}
+
+export default Carousel;


### PR DESCRIPTION
> close #15 

## 종류

<!-- PR 종류를 선택하세요 -->

- [ ] Code Review
- [x] New Feature
- [ ] Fix
- [ ] Refactor
- [ ] STYLE
- [ ] CI / CD
- [ ] DOCS
- [ ] Setup

## 내용

<!-- - 내용 명: 내용을 작성합니다. -->
- 캐러셀 컴포넌트 구현
- 현재 width는 614px로 고정 (차후 리팩토링 예정)
- this가 캐러셀을 바라볼 수 있도록 button this를 바인딩

## 체크리스트

<!-- - [ ] 체크리스트를 작성합니다. -->
- [x] 이미지가 슬라이드 되는가 ?

## 구현간 배운점

<!-- - 내용 명: 내용을 작성합니다. -->
- button에서 this가 button으로 인식되어 state를 변경하는데 이슈가 있었으나, .bind()를 통해 캐러셀로 바인딩
- style을 인라인 스타일로 객체 형태로 넣어줄 수 있음
