### PR TITLE
[#17]feat: 피드 프리젠테이셔널 & 컨테이너 컴포넌트 분리

### DIFF
--- a/src/containers/main/FeedContainer.jsx
+++ b/src/containers/main/FeedContainer.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Feed from '../../components/main/Feed';
+import Carousel from '../../shared/Carousel';
+import feeds from '../../shared/__mocks__/feeds';
+
+class FeedContainer extends React.Component {
+  render() {
+    return (
+      <>
+        {feeds.map((feed, index) => (
+          <Feed
+            key={index}
+            thumbnail={feed.thumbnail}
+            nickname={feed.nickname}
+            likes={feed.likes}
+            nickname={feed.nickname}
+            content={feed.content}
+            comments={feed.comments}
+            date={feed.date}>
+            <Carousel images={feed.images} startIndex={0} />
+          </Feed>
+        ))}
+      </>
+    );
+  }
+}
+
+export default FeedContainer;

--- a/src/index.css
+++ b/src/index.css
@@ -490,6 +490,111 @@
   cursor: pointer;
 }
 
+/* 캐러셀 */
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper
+  .carousel {
+  display: flex;
+  max-height: 768px;
+  transform: translate3d(0, 0, 0);
+  transition: transform 0.2s;
+}
+
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper
+  .carousel
+  img {
+  min-width: 614px;
+  width: 614px;
+  object-fit: contain;
+}
+
+/* 버튼 */
+
+/* 다음 */
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper
+  .next {
+  position: absolute;
+  position: absolute;
+  top: 50%;
+  right: 0;
+  padding: 16px 8px;
+  cursor: pointer;
+}
+
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper
+  .next
+  .next-image {
+  height: 30px;
+  width: 30px;
+  background: url('./images/instagram-images.png') no-repeat;
+  background-position: -162px -98px;
+}
+
+/* 이전 */
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper
+  .prev {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  padding: 16px 8px;
+  cursor: pointer;
+}
+
+.main-wrapper
+  .main-container
+  .main
+  .contents
+  .feed-wrapper
+  .feed
+  .carousel-wrapper
+  .prev
+  .prev-image {
+  height: 30px;
+  width: 30px;
+  background: url('./images/instagram-images.png') no-repeat;
+  background-position: -130px -98px;
+}
+
 .main-wrapper
   .main-container
   .main

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import Header from '../components/Header';
 import Story from '../components/main/Story';
-import Feed from '../components/main/Feed';
+import FeedContainer from '../containers/main/FeedContainer';
 import profile from '../shared/__mocks__/profile';
-import feeds from '../shared/__mocks__/feeds';
 
 class MainPage extends React.Component {
   render() {
@@ -16,17 +15,7 @@ class MainPage extends React.Component {
               <div className='contents'>
                 <Story />
                 <div className='feed-wrapper'>
-                  {feeds.map((feed, index) => (
-                    <Feed
-                      key={index}
-                      thumbnail={feed.thumbnail}
-                      nickname={feed.nickname}
-                      likes={feed.likes}
-                      nickname={feed.nickname}
-                      content={feed.content}
-                      comments={feed.comments}
-                      date={feed.date}></Feed>
-                  ))}
+                  <FeedContainer />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
> close #17 

## 종류

<!-- PR 종류를 선택하세요 -->

- [ ] Code Review
- [x] New Feature
- [ ] Fix
- [ ] Refactor
- [x] STYLE
- [ ] CI / CD
- [ ] DOCS
- [ ] Setup

## 내용

<!-- - 내용 명: 내용을 작성합니다. -->
- 피드 컴포넌트 프리젠테이셔널과 컨테이너 컴포넌트로 분리
- 데이터 처리를 컨테이너 컴포넌트에서 하도록 위임
- 피드 캐러셀 스타일링 적용

## 체크리스트

<!-- - [ ] 체크리스트를 작성합니다. -->
- [x] 프리젠테이셔널 컴포넌트는 그려주는 역할만 하는가 ?
- [x] 컨테이너 컴포넌트는 데이터 처리 역할만 하는가 ?
- [x] 화면에 데이터 처리된 컴포넌트가 그려지는가 ?
- [x] 스타일링 된 캐러셀이 피드에 적용 되었는가 ?

## 구현간 배운점

<!-- - 내용 명: 내용을 작성합니다. -->
- 프리젠테이셔널 컴포넌트와 컨테이너 컴포넌트의 분리 방법: 컴포넌트의 의도를 명확하게 나누어 관리가 쉬워지며 유지보수 하기 용이